### PR TITLE
Fixes Intl docs broken link

### DIFF
--- a/src/js/pages/INTL/README.md
+++ b/src/js/pages/INTL/README.md
@@ -4,7 +4,7 @@
 
 [Grommet Starter App](https://github.com/grommet/grommet-starter-new-app "Grommet Starter App")
 
-[react-intl getting started guide](https://github.com/formatjs/react-intl/blob/master/docs/Getting-Started.md#intro-guides "react-intl getting started guide")
+[react-intl docs](https://formatjs.io/docs/react-intl "react-intl docs")
 
 #### Installation and setup
 


### PR DESCRIPTION
Intl docs were moved to this page.
https://formatjs.io/docs/react-intl